### PR TITLE
Aligning text for Firefox 

### DIFF
--- a/_includes/data-life-cycle.html
+++ b/_includes/data-life-cycle.html
@@ -10,6 +10,7 @@
     style="enable-background: new 0 0 250.9 251; max-width: 450px"
     xml:space="preserve"
     class="sidebar_rdm"
+    text-anchor="middle"
   >
     <style type="text/css">
       .st0 {
@@ -268,25 +269,25 @@
         />
       </g>
     </a>
-    <text transform="matrix(1 0 0 1 16.4197 111.8653)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 32 111.8653)" class="st1 st8 st9">
       Share
     </text>
-    <text transform="matrix(1 0 0 1 76.3974 53.4992)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 91 53.4992)" class="st1 st8 st9">
       Reuse
     </text>
-    <text transform="matrix(1 0 0 1 19.2957 187.4998)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 50 187.4998)" class="st1 st8 st9">
       Preserve
     </text>
-    <text transform="matrix(1 0 0 1 90.1372 234.4302)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 115 234.4302)" class="st1 st8 st9">
       Analyse
     </text>
-    <text transform="matrix(1 0 0 1 162.3473 208.6529)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 185 208.6529)" class="st1 st8 st9">
       Process
     </text>
-    <text transform="matrix(1 0 0 1 159.7342 61.5168)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 170.7342 61.5168)" class="st1 st8 st9">
       Plan
     </text>
-    <text transform="matrix(1 0 0 1 197.0817 128.9797)" class="st1 st8 st9">
+    <text transform="matrix(1 0 0 1 215 128.9797)" class="st1 st8 st9">
       Collect
     </text>
   </svg>


### PR DESCRIPTION
This PR resolves the issue of the labels misaligned on Firefox.

![image](https://github.com/eur-nl/erim-research-toolbox/assets/17035406/dd3654c6-677e-4efe-8b45-f203e88ee350)

I'm creating a PR to the #56 PR branch.

Fixes #17 