### PR TITLE
Changing the link color to ERIM yellow (geelbruin)

### DIFF
--- a/_sass/_bootstrap_variables.scss
+++ b/_sass/_bootstrap_variables.scss
@@ -3,7 +3,12 @@
 // #000847 ----- CMYK: 100/90/13/68
 // #d1882a ----- CMYK: 0/35/80/18
 // #b8c3c3 ----- CMYK: 15/10/10/15
-$primary: #000847;
+
+// Define ERIM colors
+$erim-blue: #000847;
+$erim-yellow: #d18829;
+$erim-grey: #b8c3c3;
+
 $secondary: #111111;
 $light: #e2d9d7;
 $dark: #212529;

--- a/_sass/_bootstrap_variables.scss
+++ b/_sass/_bootstrap_variables.scss
@@ -9,6 +9,7 @@ $erim-blue: #000847;
 $erim-yellow: #d18829;
 $erim-grey: #b8c3c3;
 
+$primary: $erim-blue;
 $secondary: #111111;
 $light: #e2d9d7;
 $dark: #212529;
@@ -18,3 +19,4 @@ $link-decoration: none;
 $nav-link-color: $dark;
 $nav-link-hover-color: $primary;
 $font-family-sans-serif: "Museo Sans", sans-serif;
+$link-color: $erim-yellow;


### PR DESCRIPTION
This PR changes the link color to the yellow-brown color from ERIM's style guide (stijlgids 2017).


<img width="804" alt="image" src="https://github.com/eur-nl/erim-research-toolbox/assets/17035406/7e3f93aa-a4fd-40b0-826b-ac51d60cb5bf">


Fixes #38 